### PR TITLE
New Parse::Query options

### DIFF
--- a/lib/parse/api/objects.rb
+++ b/lib/parse/api/objects.rb
@@ -51,15 +51,15 @@ module Parse
       end
 
       # /1/classes/<className>/<objectId>	GET	Retrieving Objects
-      def fetch_object(className, id)
-        response = request :get, uri_path(className, id)
+      def fetch_object(className, id, opts = {})
+        response = request :get, uri_path(className, id), opts: opts
         response.parse_class = className if response.present?
         response
       end
 
       # /1/classes/<className>	GET	Queries
-      def find_objects(className, query = {})
-        response = request :get, uri_path(className), query: query
+      def find_objects(className, query = {}, opts = {})
+        response = request :get, uri_path(className), query: query, opts: opts
         response.parse_class = className if response.present?
         response
       end

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -138,7 +138,7 @@ module Parse
     # If you need to override or add additional headers to a specific request (ex. when uploading a Parse File), you can do so
     # with the header: paramter (also a hash).
     # This method also takes in a Parse::Request object instead of the arguments listed above.
-    def request(method, uri = nil, body: nil, query: nil, headers: nil)
+    def request(method, uri = nil, body: nil, query: nil, headers: nil, opts: {})
       headers ||= {}
       # if the first argument is a Parse::Request object, then construct it
       if method.is_a?(Request)
@@ -153,7 +153,7 @@ module Parse
       # http method
       method = method.downcase.to_sym
       # set the User-Agent
-      headers["User-Agent"] = "Parse-Ruby-Client v#{Parse::Stack::VERSION}"
+      headers["User-Agent".freeze] = "Parse-Stack Ruby Client v#{Parse::Stack::VERSION}".freeze
       #if it is a :get request, then use query params, otherwise body.
       params = (method == :get ? query : body) || {}
       # if the path does not start with the '/1/' prefix, then add it to be nice.

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -154,6 +154,18 @@ module Parse
       method = method.downcase.to_sym
       # set the User-Agent
       headers["User-Agent".freeze] = "Parse-Stack Ruby Client v#{Parse::Stack::VERSION}".freeze
+
+      if opts[:cache] == false
+        headers[Parse::Middleware::Caching::CACHE_CONTROL] = "no-cache"
+      elsif opts[:cache].is_a?(Numeric)
+        # future feature
+        # headers[Parse::Middleware::Caching::CACHE_CONTROL] = "max-age: #{opts[:cache].to_i}"
+      end
+
+      if opts[:use_master_key] == false
+        headers[Parse::Middleware::Authentication::DISABLE_MASTER_KEY] = "true"
+      end
+      
       #if it is a :get request, then use query params, otherwise body.
       params = (method == :get ? query : body) || {}
       # if the path does not start with the '/1/' prefix, then add it to be nice.

--- a/lib/parse/client/authentication.rb
+++ b/lib/parse/client/authentication.rb
@@ -10,6 +10,7 @@ module Parse
 
     class Authentication < Faraday::Middleware
       include Parse::Protocol
+      DISABLE_MASTER_KEY = "X-Disable-Parse-Master-Key"
       attr_accessor :application_id
       attr_accessor :api_key
       attr_accessor :master_key
@@ -32,11 +33,11 @@ module Parse
           headers = {}
           raise "No Parse Application Id specified for authentication." unless @application_id.present?
           headers[APP_ID] = @application_id
-
-          # Set a user agent
-          headers["User-Agent".freeze] = "Parse-Stack v0.0.1".freeze
           headers[API_KEY] = @api_key unless @api_key.blank?
-          headers[MASTER_KEY] = @master_key unless @master_key.blank?
+
+          unless @master_key.blank? || env[:request_headers][DISABLE_MASTER_KEY].present?
+            headers[MASTER_KEY] = @master_key
+          end
           # merge the headers with the current provided headers
           env[:request_headers].merge! headers
           # set the content type of the request if it was not provided already.

--- a/lib/parse/client/request.rb
+++ b/lib/parse/client/request.rb
@@ -5,9 +5,9 @@ module Parse
  #This class is mainly to create a potential request - mainly for the batching API.
 
   class Request
-      attr_accessor :method, :path, :body, :headers
+      attr_accessor :method, :path, :body, :headers, :opts, :cache
       attr_accessor :tag #for tracking in bulk requests
-      def initialize(method, uri, body: nil, headers: nil)
+      def initialize(method, uri, body: nil, headers: nil, opts: {})
         @tag = 0
         method = method.downcase.to_sym
         raise "Invalid Method type #{method} " unless [:get,:put,:delete,:post].include?(method)
@@ -15,6 +15,7 @@ module Parse
         self.path = uri
         self.body = body
         self.headers = headers || {}
+        self.opts = opts || {}
       end
 
 

--- a/lib/parse/query.rb
+++ b/lib/parse/query.rb
@@ -23,7 +23,7 @@ module Parse
     # You can modify the default client being used by all Parse::Query objects by setting
     # Parse::Query.client. You can override individual Parse::Query object clients
     # by changing their client variable to a different Parse::Client object.
-    attr_accessor :table, :client, :key
+    attr_accessor :table, :client, :key, :cache, :use_master_key
 
     # We have a special class method to handle field formatting. This turns
     # the symbol keys in an operand from one key to another. For example, we can
@@ -99,6 +99,8 @@ module Parse
       @limit = 100
       @skip = 0
       @table = table
+      @cache = true
+      @use_master_key = true
       conditions constraints
       self # chaining
     end # initialize
@@ -117,6 +119,10 @@ module Parse
           limit value
         elsif expression == :include || expression == :includes
           includes(value)
+        elsif expression == :cache
+          self.cache = value
+        elsif expression == :use_master_key
+          self.cache = value
         else
           add_constraint(expression, value)
         end
@@ -305,7 +311,10 @@ module Parse
     end
 
     def fetch!(compiled_query)
-      response = client.find_objects(@table, compiled_query.as_json )
+      opts = {}
+      opts[:cache] = false unless self.cache
+      opts[:use_mster_key] = self.use_master_key
+      response = client.find_objects(@table, compiled_query.as_json, opts )
       if response.error?
         puts "[ParseQuery] #{response.error}"
       end


### PR DESCRIPTION
* You can now disable the use of the cache on a per-query (and per-request) basis.
* You can now prevent the use of the Master Key on a per-query (and per-request) basis.

