### PR TITLE
Allow Moneta::Expires as cache object to allow for non-native expiring caches

### DIFF
--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -277,7 +277,7 @@ module Parse
             end
           end
 
-          unless opts[:cache].is_a?(Moneta::Transformer)
+          unless [:key?, :[], :delete, :store].all? { |method| opts[:cache].respond_to?(method) }
             raise ArgumentError, "Parse::Client option :cache needs to be a type of Moneta::Transformer store."
           end
           self.cache = opts[:cache]

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -122,7 +122,7 @@ module Parse
 
     # @!attribute cache
     #  The underlying cache store for caching API requests.
-    #  @return [Moneta::Transformer]
+    #  @return [Object]
     # @!attribute [r] application_id
     #  The Parse application identifier to be sent in every API request.
     #  @return [String]
@@ -206,8 +206,9 @@ module Parse
     #    the logging performed by {Parse::Middleware::BodyBuilder}.
     # @option opts [Object] :adapter The connection adapter. By default it uses
     #    the `Faraday.default_adapter` which is Net/HTTP.
-    # @option opts [Moneta::Transformer] :cache A caching adapter of type
-    #    {https://github.com/minad/moneta Moneta::Transformer} that will be used
+    # @option opts [Object] :cache A caching adapter of type
+    #    {https://github.com/minad/moneta Moneta::Transformer} or
+    #    {https://github.com/minad/moneta Moneta::Expires} that will be used
     #    by the caching middleware {Parse::Middleware::Caching}.
     #    Caching queries and object fetches can help improve the performance of
     #    your application, even if it is for a few seconds. Only successful GET
@@ -223,7 +224,7 @@ module Parse
     # @option opts [Hash] :faraday You may pass a hash of options that will be
     #    passed to the Faraday constructor.
     # @raise Parse::Error::ConnectionError if the client was not properly configured with required keys or url.
-    # @raise ArgumentError if the cache instance passed to the :cache option is not of Moneta::Transformer.
+    # @raise ArgumentError if the cache instance passed to the :cache option is not of Moneta::Transformer or Moneta::Expires
     # @see Parse::Middleware::BodyBuilder
     # @see Parse::Middleware::Caching
     # @see Parse::Middleware::Authentication
@@ -278,7 +279,7 @@ module Parse
           end
 
           unless [:key?, :[], :delete, :store].all? { |method| opts[:cache].respond_to?(method) }
-            raise ArgumentError, "Parse::Client option :cache needs to be a type of Moneta::Transformer store."
+            raise ArgumentError, "Parse::Client option :cache needs to be a type of Moneta store"
           end
           self.cache = opts[:cache]
           conn.use Parse::Middleware::Caching, self.cache, {expires: opts[:expires].to_i }

--- a/lib/parse/client/caching.rb
+++ b/lib/parse/client/caching.rb
@@ -81,7 +81,7 @@ module Parse
         @opts.merge!(opts) if opts.is_a?(Hash)
         @expires = @opts[:expires]
 
-        unless @store.is_a?(Moneta::Transformer)
+        unless [:key?, :[], :delete, :store].all? { |method| @store.respond_to?(method) }
           raise ArgumentError, "Caching store object must a Moneta key/value store (Moneta::Transformer)."
         end
 

--- a/lib/parse/client/caching.rb
+++ b/lib/parse/client/caching.rb
@@ -59,7 +59,7 @@ module Parse
 
       # @!attribute [rw] store
       # The internal moneta cache store instance.
-      # @return [Moneta::Transformer]
+      # @return [Object]
       attr_accessor :store
 
       # @!attribute [rw] expires
@@ -73,7 +73,7 @@ module Parse
       # @param store [Moneta] An instance of the Moneta cache store to use.
       # @param opts [Hash] additional options.
       # @option opts [Integer] :expires the default expiration for a cache entry.
-      # @raise ArgumentError, if `store` is not a Moneta::Transformer instance.
+      # @raise ArgumentError, if `store` is not a Moneta::Transformer or Moneta::Expires instance.
       def initialize(adapter, store, opts = {})
         super(adapter)
         @store = store
@@ -82,7 +82,7 @@ module Parse
         @expires = @opts[:expires]
 
         unless [:key?, :[], :delete, :store].all? { |method| @store.respond_to?(method) }
-          raise ArgumentError, "Caching store object must a Moneta key/value store (Moneta::Transformer)."
+          raise ArgumentError, "Caching store object must a Moneta key/value store."
         end
 
       end

--- a/test/lib/parse/cache_test.rb
+++ b/test/lib/parse/cache_test.rb
@@ -1,0 +1,32 @@
+require_relative '../../test_helper'
+
+class TestCache < Minitest::Test
+  def setup
+    @init_object = {
+      server_url: 'http://b.com/parse',
+      app_id: 'abc',
+      api_key: 'def'
+    }
+  end
+
+  def test_no_cache_ok
+    assert Parse.setup(@init_object)
+  end
+
+  def test_moneta_transformer_accepted
+    init = @init_object.merge(cache: Moneta.new(:LRUHash))
+    assert init[:cache].is_a?(Moneta::Transformer)
+    assert Parse.setup(init)
+  end
+
+  def test_moneta_expire_accepted
+    init = @init_object.merge(cache: Moneta.new(:LRUHash, expires: 13))
+    assert init[:cache].is_a?(Moneta::Expires)
+    assert Parse.setup(init)
+  end
+
+  def test_bad_cache_type_rejected
+    init = @init_object.merge(cache: 'hamster')
+    assert_raises(ArgumentError) { Parse.setup(init) }
+  end
+end


### PR DESCRIPTION
Small change to allow use of Moneta::Expires proxy when not using an adaptor with native expiry.

Could have changed the check for Moneta::Transformer to also check for Moneta::Expires too, but now checking for the methods used being present. Think this is OK?