### PR TITLE
Ruby3, faraday2 compatibility, remove parse native collection override templates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     parse-stack (1.10.0)
-      active_model_serializers (>= 0.9, < 1)
-      activemodel (>= 5, < 7)
-      activesupport (>= 5, < 7)
-      faraday (< 1)
-      faraday_middleware (>= 0.9, < 2)
-      moneta (< 2)
-      parallel (>= 1.6, < 2)
-      rack (>= 2.0.6, < 3)
+      active_model_serializers (>= 0.9)
+      activemodel (>= 5)
+      activesupport (>= 5)
+      faraday
+      faraday_middleware (>= 0.9)
+      moneta
+      parallel (>= 1.6)
+      rack (>= 2.0.6)
 
 GEM
   remote: https://rubygems.org/
@@ -155,6 +155,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   byebug

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -481,7 +481,7 @@ module Parse
         retry
       end
       raise
-    rescue Faraday::Error::ClientError, Net::OpenTimeout => e
+    rescue Faraday::ClientError, Net::OpenTimeout => e
       if _retry_count > 0
         warn "[Parse:Retry] Retries remaining #{_retry_count} : #{_request}"
         _retry_count -= 1

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -2,7 +2,7 @@ require "faraday"
 require "faraday_middleware"
 require "active_support"
 require "moneta"
-require "active_model_serializers"
+
 require "active_support/inflector"
 require "active_support/core_ext/object"
 require "active_support/core_ext/string"

--- a/lib/parse/client/body_builder.rb
+++ b/lib/parse/client/body_builder.rb
@@ -7,7 +7,7 @@ require_relative "response"
 require_relative "protocol"
 require "active_support"
 require "active_support/core_ext"
-require "active_model_serializers"
+
 
 module Parse
 

--- a/lib/parse/model/core/builder.rb
+++ b/lib/parse/model/core/builder.rb
@@ -43,6 +43,10 @@ module Parse
           raise ArgumentError, "No valid className provided for schema hash"
         end
 
+        # Remove leading underscore, as ruby constants have to start with an uppercase letter
+
+        className = className[1..] if className[0] == '_'
+
         begin
           klass = Parse::Model.find_class className
           klass = ::Object.const_get(className.to_parse_class) if klass.nil?

--- a/lib/parse/model/core/properties.rb
+++ b/lib/parse/model/core/properties.rb
@@ -7,9 +7,9 @@ require "active_support/inflector"
 require "active_support/core_ext"
 require "active_support/core_ext/object"
 require "active_support/inflector"
-require "active_model_serializers"
+
 require "active_support/inflector"
-require "active_model_serializers"
+
 require "active_support/hash_with_indifferent_access"
 require "time"
 

--- a/lib/parse/model/date.rb
+++ b/lib/parse/model/date.rb
@@ -10,7 +10,7 @@ require "active_support/core_ext/object"
 require "active_support/core_ext/date/calculations"
 require "active_support/core_ext/date_time/calculations"
 require "active_support/core_ext/time/calculations"
-require "active_model_serializers"
+
 require_relative "model"
 
 module Parse

--- a/lib/parse/model/model.rb
+++ b/lib/parse/model/model.rb
@@ -5,7 +5,7 @@ require "active_model"
 require "active_support"
 require "active_support/inflector"
 require "active_support/core_ext/object"
-require "active_model_serializers"
+
 require_relative "../client"
 
 module Parse

--- a/lib/parse/model/object.rb
+++ b/lib/parse/model/object.rb
@@ -7,7 +7,7 @@ require "active_support/inflector"
 require "active_support/core_ext"
 require "active_support/core_ext/object"
 require "active_support/core_ext/string"
-require "active_model_serializers"
+
 require "time"
 require "open-uri"
 

--- a/lib/parse/model/pointer.rb
+++ b/lib/parse/model/pointer.rb
@@ -5,7 +5,7 @@ require "active_model"
 require "active_support"
 require "active_support/inflector"
 require "active_support/core_ext"
-require "active_model_serializers"
+
 require_relative "model"
 
 module Parse

--- a/lib/parse/model/push.rb
+++ b/lib/parse/model/push.rb
@@ -3,7 +3,7 @@
 
 require_relative "../query.rb"
 require_relative "../client.rb"
-require "active_model_serializers"
+
 
 module Parse
   # This class represents the API to send push notification to devices that are

--- a/lib/parse/query.rb
+++ b/lib/parse/query.rb
@@ -6,7 +6,7 @@ require_relative "query/operation"
 require_relative "query/constraints"
 require_relative "query/ordering"
 require "active_model"
-require "active_model_serializers"
+
 require "active_support"
 require "active_support/inflector"
 require "active_support/core_ext"

--- a/lib/parse/stack/generators/rails.rb
+++ b/lib/parse/stack/generators/rails.rb
@@ -16,11 +16,11 @@ module ParseStack
     # @!visibility private
     def generate_initializer
       copy_file "parse.rb", "config/initializers/parse.rb"
-      copy_file "model_user.rb", File.join("app/models", "user.rb")
-      copy_file "model_role.rb", File.join("app/models", "role.rb")
-      copy_file "model_session.rb", File.join("app/models", "session.rb")
-      copy_file "model_installation.rb", File.join("app/models", "installation.rb")
-      copy_file "webhooks.rb", File.join("app/models", "webhooks.rb")
+      #copy_file "model_user.rb", File.join("app/models", "user.rb")
+      #copy_file "model_role.rb", File.join("app/models", "role.rb")
+      #copy_file "model_session.rb", File.join("app/models", "session.rb")
+      #copy_file "model_installation.rb", File.join("app/models", "installation.rb")
+      #copy_file "webhooks.rb", File.join("app/models", "webhooks.rb")
     end
   end
 

--- a/lib/parse/stack/tasks.rb
+++ b/lib/parse/stack/tasks.rb
@@ -117,7 +117,7 @@ module Parse
 
               task :triggers => :verify_env do
                 endpoint = ENV["HOOKS_URL"]
-                Parse::Webhooks.register_triggers!(endpoint, { include_wildcard: true }) do |trigger, name|
+                Parse::Webhooks.register_triggers!(endpoint, include_wildcard: true) do |trigger, name|
                   puts "[+] #{trigger.to_s.ljust(12, " ")} - #{name}"
                 end
               end

--- a/lib/parse/webhooks.rb
+++ b/lib/parse/webhooks.rb
@@ -53,18 +53,18 @@ module Parse
     # @yield the body of the function to be evaluated in the scope of a {Parse::Webhooks::Payload} instance.
     # @param block [Symbol] the name of the method to call, if no block is passed.
     # @return (see Parse::Webhooks.route)
-    def self.webhook(type, block = nil)
+    def self.webhook(type, function=nil, &block)
       if type == :function
-        unless block.is_a?(String) || block.is_a?(Symbol)
-          raise ArgumentError, "Invalid Cloud Code function name: #{block}"
+        unless function.is_a?(String) || function.is_a?(Symbol)
+          raise ArgumentError, "Invalid Cloud Code function name: #{function}"
         end
-        Parse::Webhooks.route(:function, block, &Proc.new)
+        Parse::Webhooks.route(:function, function, block)
         # then block must be a symbol or a string
       else
-        if block_given?
-          Parse::Webhooks.route(type, self, &Proc.new)
-        else
+        if block
           Parse::Webhooks.route(type, self, block)
+        else
+          Parse::Webhooks.route(type, self, function)
         end
       end
       #if block
@@ -125,7 +125,7 @@ module Parse
       #  name to register with Parse server.
       # @yield the block that will handle of the webhook trigger or function.
       # @return (see routes)
-      def route(type, className, &block)
+      def route(type, className, block)
         type = type.to_s.underscore.to_sym #support camelcase
         if type != :function && className.respond_to?(:parse_class)
           className = className.parse_class

--- a/lib/parse/webhooks.rb
+++ b/lib/parse/webhooks.rb
@@ -125,7 +125,7 @@ module Parse
       #  name to register with Parse server.
       # @yield the block that will handle of the webhook trigger or function.
       # @return (see routes)
-      def route(type, className, block)
+      def route(type, className, &block)
         type = type.to_s.underscore.to_sym #support camelcase
         if type != :function && className.respond_to?(:parse_class)
           className = className.parse_class

--- a/lib/parse/webhooks.rb
+++ b/lib/parse/webhooks.rb
@@ -6,7 +6,7 @@ require "active_support"
 require "active_support/inflector"
 require "active_support/core_ext/object"
 require "active_support/core_ext"
-require "active_model_serializers"
+
 require "rack"
 require_relative "client"
 require_relative "stack"

--- a/lib/parse/webhooks/payload.rb
+++ b/lib/parse/webhooks/payload.rb
@@ -7,7 +7,7 @@ require "active_support/inflector"
 require "active_support/core_ext/object"
 require "active_support/core_ext/string"
 require "active_support/core_ext"
-require "active_model_serializers"
+
 
 module Parse
   class Webhooks
@@ -125,7 +125,7 @@ module Parse
       def parse_id
         return nil unless @object.present?
         @object[Parse::Model::OBJECT_ID] || @object[:objectId]
-      end; 
+      end;
       alias_method :objectId, :parse_id
 
       # true if this is a webhook trigger request.

--- a/parse-stack.gemspec
+++ b/parse-stack.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "parallel", [">= 1.6"]
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faraday_middleware", [">= 0.9"]
-  spec.add_runtime_dependency "moneta",
+  spec.add_runtime_dependency "moneta"
   spec.add_runtime_dependency "rack", ">= 2.0.6"
 
   #   spec.post_install_message = <<UPGRADE

--- a/parse-stack.gemspec
+++ b/parse-stack.gemspec
@@ -27,14 +27,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_runtime_dependency "activemodel", [">= 5", "< 7"]
-  spec.add_runtime_dependency "active_model_serializers", [">= 0.9", "< 1"]
-  spec.add_runtime_dependency "activesupport", [">= 5", "< 7"]
-  spec.add_runtime_dependency "parallel", [">= 1.6", "< 2"]
-  spec.add_runtime_dependency "faraday", "< 1"
-  spec.add_runtime_dependency "faraday_middleware", [">= 0.9", "< 2"]
-  spec.add_runtime_dependency "moneta", "< 2"
-  spec.add_runtime_dependency "rack", ">= 2.0.6", "< 3"
+  spec.add_runtime_dependency "activemodel", [">= 5"]
+  spec.add_runtime_dependency "active_model_serializers", [">= 0.9"]
+  spec.add_runtime_dependency "activesupport", [">= 5"]
+  spec.add_runtime_dependency "parallel", [">= 1.6"]
+  spec.add_runtime_dependency "faraday"
+  spec.add_runtime_dependency "faraday_middleware", [">= 0.9"]
+  spec.add_runtime_dependency "moneta",
+  spec.add_runtime_dependency "rack", ">= 2.0.6"
 
   #   spec.post_install_message = <<UPGRADE
   #


### PR DESCRIPTION
Minor changes to bring compatibility with ruby 3 and faraday 2. Remove parse native collections models override templates that don't work.